### PR TITLE
Added target

### DIFF
--- a/NLog.ManualFlush/NLog.ManualFlush/ManualFlushWrapper.cs
+++ b/NLog.ManualFlush/NLog.ManualFlush/ManualFlushWrapper.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 namespace NLog.ManualFlush
 {
+    [Target("ManualFlush")]
     public class ManualFlushWrapper : WrapperTargetBase
     {
         private readonly IList<AsyncLogEventInfo> logs = new List<AsyncLogEventInfo>();


### PR DESCRIPTION
Without the Target attribute, Nlog will not be able to find this target
