### PR TITLE
feat(Logical Context): The equivalent to log4net.ThreadLogicalContext

### DIFF
--- a/NLog-Contrib.sln
+++ b/NLog-Contrib.sln
@@ -20,6 +20,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.ManualFlush", "NLog.Ma
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.ManualFlush.Tests", "NLog.ManualFlush.Tests\NLog.ManualFlush.Tests.csproj", "{4F85E4C4-F0D7-43B8-B42F-F55F3AFCCAB3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLogContrib", "NLogContrib\NLogContrib.csproj", "{1EF270BC-EC8C-444B-9D05-B2F6C234F704}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLogContrib.Tests", "NLogContrib.Tests\NLogContrib.Tests.csproj", "{833FD6B8-32F7-475D-B67C-939A05682978}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,6 +50,14 @@ Global
 		{4F85E4C4-F0D7-43B8-B42F-F55F3AFCCAB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F85E4C4-F0D7-43B8-B42F-F55F3AFCCAB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F85E4C4-F0D7-43B8-B42F-F55F3AFCCAB3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1EF270BC-EC8C-444B-9D05-B2F6C234F704}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EF270BC-EC8C-444B-9D05-B2F6C234F704}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EF270BC-EC8C-444B-9D05-B2F6C234F704}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1EF270BC-EC8C-444B-9D05-B2F6C234F704}.Release|Any CPU.Build.0 = Release|Any CPU
+		{833FD6B8-32F7-475D-B67C-939A05682978}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{833FD6B8-32F7-475D-B67C-939A05682978}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{833FD6B8-32F7-475D-B67C-939A05682978}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{833FD6B8-32F7-475D-B67C-939A05682978}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NLogContrib.Tests/LayoutRenderers/MDLCTests.cs
+++ b/NLogContrib.Tests/LayoutRenderers/MDLCTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using NLog;
+using NLog.Config;
+using NLogContrib;
+using NLogContrib.LayoutRenderers;
+using NUnit.Framework;
+
+namespace NLogContrib.Tests.LayoutRenderers
+{
+    [TestFixture]
+    public class MDLCTests
+    {
+        [SetUp]
+        public static void SetUp()
+        {
+            NLog.Config.ConfigurationItemFactory.Default.LayoutRenderers.RegisterDefinition("mdlc", typeof(MdlcLayoutRenderer));
+
+            string cfgStr = @"
+            <nlog>
+                <targets><target name='debug' type='Debug' layout='${mdlc:item=myitem} ${message}' /></targets>
+                <rules>
+                    <logger name='*' minlevel='Debug' writeTo='debug' />
+                </rules>
+            </nlog>";
+
+            XElement el = XElement.Parse(cfgStr);
+            XmlLoggingConfiguration cfg = new XmlLoggingConfiguration(el.CreateReader(), null);
+            LogManager.Configuration = cfg;
+        }
+
+
+        [Test]
+        public void MDLCSingleThreadTest()
+        {
+            var dbgTarget = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName("debug");
+
+            MappedDiagnosticsLogicalContext.Clear();
+            MappedDiagnosticsLogicalContext.Set("myitem", "myvalue");
+            LogManager.GetLogger("A").Debug("a");
+            Assert.AreEqual("myvalue a", dbgTarget.LastMessage);
+
+            MappedDiagnosticsLogicalContext.Set("myitem", "value2");
+            LogManager.GetLogger("A").Debug("b");
+            Assert.AreEqual("value2 b", dbgTarget.LastMessage);
+
+
+            MappedDiagnosticsLogicalContext.Remove("myitem");
+            LogManager.GetLogger("A").Debug("c");
+            Assert.AreEqual(" c", dbgTarget.LastMessage);
+        }
+
+        [Test]
+        public void MDLCMultiThreadTest()
+        {
+            var dbgTarget = (NLog.Targets.DebugTarget)LogManager.Configuration.FindTargetByName("debug");
+
+            MappedDiagnosticsLogicalContext.Clear();
+            MappedDiagnosticsLogicalContext.Set("myitem", "myvalue");
+            LogManager.GetLogger("A").Debug("a");
+            Assert.AreEqual("myvalue a", dbgTarget.LastMessage);
+
+
+            var task1 = Task<string>.Run(() =>
+                {
+                    LogManager.GetLogger("A").Debug("b");
+                    return dbgTarget.LastMessage;
+                });
+
+            task1.Wait();
+            Assert.AreEqual("myvalue b", dbgTarget.LastMessage);
+        }
+    }
+}

--- a/NLogContrib.Tests/NLogContrib.Tests.csproj
+++ b/NLogContrib.Tests/NLogContrib.Tests.csproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{833FD6B8-32F7-475D-B67C-939A05682978}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NLogContrib.Tests</RootNamespace>
+    <AssemblyName>NLogContrib.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NLog">
+      <HintPath>..\packages\NLog.2.0.1.2\lib\net45\NLog.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="LayoutRenderers\MDLCTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NLogContrib\NLogContrib.csproj">
+      <Project>{1ef270bc-ec8c-444b-9d05-b2f6c234f704}</Project>
+      <Name>NLogContrib</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/NLogContrib.Tests/Properties/AssemblyInfo.cs
+++ b/NLogContrib.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NLogContrib.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Agilior")]
+[assembly: AssemblyProduct("NLogContrib.Tests")]
+[assembly: AssemblyCopyright("Copyright © Agilior 2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("495fef42-785a-47eb-a2ee-e8707a943c58")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NLogContrib.Tests/packages.config
+++ b/NLogContrib.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NLog" version="2.0.1.2" targetFramework="net45" />
+  <package id="NUnit" version="2.6.2" targetFramework="net45" />
+</packages>

--- a/NLogContrib/LayoutRenderers/MdlcLayoutRenderer.cs
+++ b/NLogContrib/LayoutRenderers/MdlcLayoutRenderer.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NLog;
+using NLog.Config;
+using NLog.LayoutRenderers;
+
+namespace NLogContrib.LayoutRenderers
+{
+    /// <summary>
+    /// Mapped Diagnostic Logical Context item (based on CallContext).
+    /// </summary>
+    [LayoutRenderer("mdlc")]
+    public class MdlcLayoutRenderer : LayoutRenderer
+    {
+        /// <summary>
+        /// Gets or sets the name of the item.
+        /// </summary>
+        /// <docgen category='Rendering Options' order='10' />
+        [RequiredParameter]
+        [DefaultParameter]
+        public string Item { get; set; }
+
+        /// <summary>
+        /// Renders the specified MDLC item and appends it to the specified <see cref="StringBuilder" />.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder"/> to append the rendered data to.</param>
+        /// <param name="logEvent">Logging event.</param>
+        protected override void Append(StringBuilder builder, LogEventInfo logEvent)
+        {
+            string msg = MappedDiagnosticsLogicalContext.Get(this.Item);
+            builder.Append(msg);
+        }
+    }
+
+}

--- a/NLogContrib/MappedDiagnosticsLogicalContext.cs
+++ b/NLogContrib/MappedDiagnosticsLogicalContext.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Remoting.Messaging;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NLogContrib
+{
+    /// <summary>
+    /// Mapped Diagnostics Logical Context - a logical context structure that keeps a dictionary
+    /// of strings and provides methods to output them in layouts.
+    /// Mostly for compatibility with log4net (log4net.ThreadLogicalContext).
+    /// </summary>
+    public static class MappedDiagnosticsLogicalContext
+    {
+        private const string LogicalContextDictKey = "NLog.MappedDiagnosticsLogicalContext";
+
+        private static IDictionary<string, string> LogicalContextDict
+        {
+            get
+            {
+                var dict = CallContext.LogicalGetData(LogicalContextDictKey) as ConcurrentDictionary<string, string>;
+                if (dict == null)
+                {
+                    dict = new ConcurrentDictionary<string, string>();
+                    CallContext.LogicalSetData(LogicalContextDictKey, dict);
+                }
+                return dict;
+            }
+        }
+
+        /// <summary>
+        /// Sets the current logical context item to the specified value.
+        /// </summary>
+        /// <param name="item">Item name.</param>
+        /// <param name="value">Item value.</param>
+        public static void Set(string item, string value)
+        {
+            LogicalContextDict[item] = value;
+        }
+
+        /// <summary>
+        /// Gets the current logical context named item.
+        /// </summary>
+        /// <param name="item">Item name.</param>
+        /// <returns>The item value of string.Empty if the value is not present.</returns>
+        public static string Get(string item)
+        {
+            string s;
+
+            if (!LogicalContextDict.TryGetValue(item, out s))
+            {
+                s = string.Empty;
+            }
+
+            return s;
+        }
+
+        /// <summary>
+        /// Checks whether the specified item exists in current logical context.
+        /// </summary>
+        /// <param name="item">Item name.</param>
+        /// <returns>A boolean indicating whether the specified item exists in current thread MDC.</returns>
+        public static bool Contains(string item)
+        {
+            return LogicalContextDict.ContainsKey(item);
+        }
+
+        /// <summary>
+        /// Removes the specified item from current logical context.
+        /// </summary>
+        /// <param name="item">Item name.</param>
+        public static void Remove(string item)
+        {
+            LogicalContextDict.Remove(item);
+        }
+
+        /// <summary>
+        /// Clears the content of current logical context.
+        /// </summary>
+        public static void Clear()
+        {
+            LogicalContextDict.Clear();
+        }
+    }
+}

--- a/NLogContrib/NLogContrib.csproj
+++ b/NLogContrib/NLogContrib.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1EF270BC-EC8C-444B-9D05-B2F6C234F704}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NLogContrib</RootNamespace>
+    <AssemblyName>NLogContrib</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NLog">
+      <HintPath>..\packages\NLog.2.0.1.2\lib\net45\NLog.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="LayoutRenderers\MdlcLayoutRenderer.cs" />
+    <Compile Include="MappedDiagnosticsLogicalContext.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/NLogContrib/Properties/AssemblyInfo.cs
+++ b/NLogContrib/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NLogContrib")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NLogContrib")]
+[assembly: AssemblyCopyright("Copyright © 2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("23b80d3d-7be2-42bd-a04d-11051c2b6930")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NLogContrib/packages.config
+++ b/NLogContrib/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NLog" version="2.0.1.2" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Adds Support for the equivalent to log4net.ThreadLogicalContext

The MappedDiagnosticsContext stores the dictionary in the thread locall storage, which it does not flow in async points. For example, if I am using the async/await pattern in my web application, and I want to log a specific property (being set in the begining of the request processing), in all my log statements, if I use the MappedDiagnosticsContext, I will lose the property in logs as soon the request jump to another thread.

This PR will allows us to use a class,MappedDiagnosticsLogicalContext, which uses the CallContext to store the items. A new layout renderer is included as well (${mdlc}).
